### PR TITLE
Fix demo promotion date formatting for API compatibility

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -51,6 +51,21 @@ const Utils = {
         return new Date(date).toISOString().slice(0, 16);
     },
 
+    // Format date and time for API (YYYY-MM-DD HH:MM:SS)
+    formatDateTimeForApi(date) {
+        const d = new Date(date);
+        const pad = (value) => value.toString().padStart(2, '0');
+
+        const year = d.getFullYear();
+        const month = pad(d.getMonth() + 1);
+        const day = pad(d.getDate());
+        const hours = pad(d.getHours());
+        const minutes = pad(d.getMinutes());
+        const seconds = pad(d.getSeconds());
+
+        return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+    },
+
     // Show loading spinner
     showLoading(element) {
         element.innerHTML = '<div class="flex justify-center p-8"><div class="loading-spinner"></div></div>';

--- a/js/public-catalog.js
+++ b/js/public-catalog.js
@@ -579,6 +579,19 @@ async function createDemoProducts() {
 
 // Create Demo Promotions
 async function createDemoPromotions() {
+    const getPromotionPeriod = (durationInDays) => {
+        const start = new Date();
+        const end = new Date(start.getTime() + durationInDays * 24 * 60 * 60 * 1000);
+
+        return {
+            start: Utils.formatDateTimeForApi(start),
+            end: Utils.formatDateTimeForApi(end)
+        };
+    };
+
+    const firstPromotionPeriod = getPromotionPeriod(30);
+    const secondPromotionPeriod = getPromotionPeriod(15);
+
     const demoPromotions = [
         {
             titulo: '¡2x1 en Jugos Naturales!',
@@ -586,8 +599,8 @@ async function createDemoPromotions() {
             tipo: '2x1',
             valor_descuento: 0,
             productos_aplicables: [],
-            fecha_inicio: Date.now(),
-            fecha_fin: Date.now() + (30 * 24 * 60 * 60 * 1000), // 30 days
+            fecha_inicio: firstPromotionPeriod.start,
+            fecha_fin: firstPromotionPeriod.end,
             activa: true,
             imagen_url: 'https://images.unsplash.com/photo-1553530666-ba11a7da3888?w=800&h=400&fit=crop'
         },
@@ -597,8 +610,8 @@ async function createDemoPromotions() {
             tipo: 'descuento_porcentaje',
             valor_descuento: 20,
             productos_aplicables: [],
-            fecha_inicio: Date.now(),
-            fecha_fin: Date.now() + (15 * 24 * 60 * 60 * 1000), // 15 days
+            fecha_inicio: secondPromotionPeriod.start,
+            fecha_fin: secondPromotionPeriod.end,
             activa: true,
             imagen_url: 'https://images.unsplash.com/photo-1551997070-8b7c0d637ee8?w=800&h=400&fit=crop'
         }


### PR DESCRIPTION
## Summary
- add a utility helper to format date and time strings to the API-required pattern
- update demo promotion creation to send formatted start and end dates that satisfy backend validation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9609ca19c832aa179a1d948e3cc8b