### PR TITLE
Fix promociones timestamps to match database schema

### DIFF
--- a/backend/api/controllers/BaseController.php
+++ b/backend/api/controllers/BaseController.php
@@ -8,6 +8,8 @@ abstract class BaseController {
     protected $db;
     protected $table;
     protected $primaryKey = 'id';
+    protected $createdAtField = 'created_at';
+    protected $updatedAtField = 'updated_at';
     
     public function __construct($database) {
         $this->db = $database;
@@ -107,7 +109,7 @@ abstract class BaseController {
             }
             
             // Agregar timestamps
-            $data = $this->db->prepareInsertData($data);
+            $data = $this->db->prepareInsertData($data, true, $this->getTimestampFields());
             
             // Construir query de inserción
             $fields = array_keys($data);
@@ -142,7 +144,7 @@ abstract class BaseController {
             
             // Preparar datos
             $data = $this->beforeUpdate($data, $existing);
-            $data = $this->db->prepareUpdateData($data);
+            $data = $this->db->prepareUpdateData($data, $this->getTimestampFields());
             
             // Asegurar que el ID no se modifique
             unset($data[$this->primaryKey]);
@@ -185,7 +187,7 @@ abstract class BaseController {
             
             // Preparar datos
             $data = $this->beforeUpdate($data, $existing);
-            $data = $this->db->prepareUpdateData($data);
+            $data = $this->db->prepareUpdateData($data, $this->getTimestampFields());
             
             // Asegurar que el ID no se modifique
             unset($data[$this->primaryKey]);
@@ -344,6 +346,13 @@ abstract class BaseController {
         } catch (Exception $e) {
             return [];
         }
+    }
+
+    protected function getTimestampFields() {
+        return [
+            'created' => $this->createdAtField,
+            'updated' => $this->updatedAtField
+        ];
     }
 }
 ?>

--- a/backend/api/controllers/PromocionesController.php
+++ b/backend/api/controllers/PromocionesController.php
@@ -17,6 +17,8 @@ class PromocionesController extends BaseController {
     public function __construct($database) {
         parent::__construct($database);
         $this->table = 'promociones';
+        $this->createdAtField = 'fecha_creacion';
+        $this->updatedAtField = null;
     }
     
     protected function validateData($data, $operation) {
@@ -313,12 +315,19 @@ class PromocionesController extends BaseController {
             $promocion = $this->getById($id);
             $newStatus = !$promocion['activa'];
             
-            $query = "UPDATE {$this->table} SET activa = :activa, updated_at = NOW() WHERE id = :id";
-            
-            $this->db->update($query, [
+            $setClause = 'activa = :activa';
+            $params = [
                 'id' => $id,
                 'activa' => $newStatus ? 1 : 0
-            ]);
+            ];
+
+            if (!empty($this->updatedAtField)) {
+                $setClause .= ", {$this->updatedAtField} = NOW()";
+            }
+
+            $query = "UPDATE {$this->table} SET {$setClause} WHERE id = :id";
+
+            $this->db->update($query, $params);
             
             return $this->getById($id);
             

--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -200,20 +200,37 @@ class Database {
     /**
      * Preparar datos para inserción con timestamps
      */
-    public function prepareInsertData($data, $includeTimestamps = true) {
+    public function prepareInsertData($data, $includeTimestamps = true, $timestampFields = null) {
         if ($includeTimestamps) {
-            $data['created_at'] = date('Y-m-d H:i:s');
-            $data['updated_at'] = date('Y-m-d H:i:s');
+            $timestampFields = $timestampFields ?? [];
+            $createdField = $timestampFields['created'] ?? 'created_at';
+            $updatedField = $timestampFields['updated'] ?? 'updated_at';
+
+            $now = date('Y-m-d H:i:s');
+
+            if (!empty($createdField)) {
+                $data[$createdField] = $now;
+            }
+
+            if (!empty($updatedField)) {
+                $data[$updatedField] = $now;
+            }
         }
-        
+
         return $data;
     }
-    
+
     /**
      * Preparar datos para actualización con timestamp
      */
-    public function prepareUpdateData($data) {
-        $data['updated_at'] = date('Y-m-d H:i:s');
+    public function prepareUpdateData($data, $timestampFields = null) {
+        $timestampFields = $timestampFields ?? [];
+        $updatedField = $timestampFields['updated'] ?? 'updated_at';
+
+        if (!empty($updatedField)) {
+            $data[$updatedField] = date('Y-m-d H:i:s');
+        }
+
         return $data;
     }
     


### PR DESCRIPTION
## Summary
- allow controllers to configure timestamp field names when preparing insert and update payloads
- configure PromocionesController to use fecha_creacion and avoid non-existent updated_at column
- update toggleActive to only touch timestamp column when available

## Testing
- php -l backend/api/controllers/PromocionesController.php

------
https://chatgpt.com/codex/tasks/task_e_68e96bba8ed8832aa972e1ae232424e9