### PR TITLE
Fix promociones timestamp handling

### DIFF
--- a/backend/api/controllers/PromocionesController.php
+++ b/backend/api/controllers/PromocionesController.php
@@ -18,7 +18,10 @@ class PromocionesController extends BaseController {
         parent::__construct($database);
         $this->table = 'promociones';
         $this->createdAtField = 'fecha_creacion';
-        $this->updatedAtField = null;
+        // Esta tabla no cuenta con una columna de actualización automática.
+        // Usamos cadena vacía para evitar que el BaseController intente
+        // utilizar el valor por defecto "updated_at".
+        $this->updatedAtField = '';
     }
     
     protected function validateData($data, $operation) {


### PR DESCRIPTION
## Summary
- avoid inserting the default updated_at column when creating promociones by clearing the timestamp field override
- document the reason in the controller so future changes understand why updated timestamps are skipped

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e96eaffd78832a9bcb015df6b09e12